### PR TITLE
fix(global): test_update_(user/account)

### DIFF
--- a/src/account/application/account/updater.py
+++ b/src/account/application/account/updater.py
@@ -38,4 +38,7 @@ class AccountUpdater:
         except EntityNotFound as e:
             raise AccountNotFound(account_id=request.id) from e
 
+        account.rename(request.name)
+        account.modify_reference_balance(request.reference_balance)
+
         self._repository.update(account)


### PR DESCRIPTION
    fix(user): fix test_update_user test which was incorrect
    replace pytest-mocking spy method by persisted user content comparison

    fix(account): fix test_update_account test which was incorrect
    Replace pytest-mocking spy method by persisted account content comparison.
    It permitted to highlight that UserUpdater was not correctly implemented. It has been fixed.